### PR TITLE
Update to latest fabrary data packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": "http://aongaro.github.io/fab-eco-proxy",
   "dependencies": {
+    "@flesh-and-blood/cards": "^0.0.97",
+    "@flesh-and-blood/types": "^0.0.97",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -15,7 +17,6 @@
     "@types/react-dom": "^18.0.0",
     "@types/uuid": "^9.0.0",
     "bootstrap": "^5.2.3",
-    "fab-cards": "^7.1.62",
     "fuse.js": "^6.6.2",
     "lodash": "^4.17.21",
     "lunr": "^2.3.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { CardsDB } from "./db/cardDB";
 import EcoProxyCard from "./db/interfaces";
 import Logo from "./images/logopng.png";
 import FABListInput from "./components/FABListInput";
-import { Card as FabCard } from "fab-cards";
+import { Card as FabCard } from "@flesh-and-blood/types";
 import FABCardManager from "./components/FABCardManager";
 import HelpModal from "./components/HelpModal";
 import SearchModal from "./components/SearchModal";

--- a/src/components/FABCardSearch.tsx
+++ b/src/components/FABCardSearch.tsx
@@ -11,7 +11,7 @@ import {
   Row,
 } from "react-bootstrap";
 import EcoProxyCard from "../db/interfaces";
-import { Card } from "fab-cards";
+import { Card } from "@flesh-and-blood/types";
 import FABCardsListItem from "./FABCardSearchListItemt";
 import ToggleButton from "react-bootstrap/ToggleButton";
 import * as Icon from "react-bootstrap-icons";

--- a/src/db/cardDB.ts
+++ b/src/db/cardDB.ts
@@ -1,4 +1,5 @@
-import { Card, cards } from "fab-cards";
+import { cards } from "@flesh-and-blood/cards";
+import { Card } from "@flesh-and-blood/types";
 import { v4 as uuidv4 } from "uuid";
 import EcoProxyCard from "./interfaces";
 import Fuse from "fuse.js";

--- a/src/db/interfaces.ts
+++ b/src/db/interfaces.ts
@@ -1,4 +1,4 @@
-import { Card } from "fab-cards";
+import { Card } from "@flesh-and-blood/types";
 
 export default interface EcoProxyCard extends Card {
   uuid?: string;

--- a/src/db/oldLunr.ts
+++ b/src/db/oldLunr.ts
@@ -1,5 +1,5 @@
 import lunr from "lunr";
-import { cards } from "fab-cards";
+import { cards } from "@flesh-and-blood/cards";
 import { v4 as uuidv4 } from "uuid";
 import EcoProxyCard from "./interfaces";
 import sortBy from "lodash/sortBy";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@flesh-and-blood/cards@^0.0.97":
+  version "0.0.97"
+  resolved "https://registry.yarnpkg.com/@flesh-and-blood/cards/-/cards-0.0.97.tgz#ac5a45a8a0051daaeb36a343456da0724e3b6505"
+  integrity sha512-o1D/jivu6H18xoPi6YgrsswAnikmDQCeCBWaGDccm1/oKwatwx1RbaQNQmhgiDFtWNBldymy+xOoWcxx6w3S1Q==
+  dependencies:
+    "@flesh-and-blood/types" "^0.0.97"
+
+"@flesh-and-blood/types@^0.0.97":
+  version "0.0.97"
+  resolved "https://registry.yarnpkg.com/@flesh-and-blood/types/-/types-0.0.97.tgz#be290c6557eeda81fb53d1fdfe2fca6193ac91fa"
+  integrity sha512-/8NecO1+9UIBwgp4cW1rRF5jlYU8MD901yfnvPaMAjzRWvCRVKl73bC0Kd8ihtqyUYPSBUr2XhEJdD8XeD5IwQ==
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.7.tgz#38aec044c6c828f6ed51d5d7ae3d9b9faf6dbb0f"
@@ -4494,11 +4506,6 @@ extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-fab-cards@^7.1.62:
-  version "7.1.62"
-  resolved "https://registry.yarnpkg.com/fab-cards/-/fab-cards-7.1.62.tgz#70461bf33b0c108edbd667168321dca9375df216"
-  integrity sha512-NsTr2sU1CTGWJgvhu35pRZ9W8/aPO3TRDC2Gw8pYLedV1dArGO3umZIyeFeTHGTYdEs00m3IEfDbVfKUXONjZQ==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"


### PR DESCRIPTION
👋 I really like your project. I've used it to test out a lot of decks. I find these proxies to be much more legible than ones using the card image. And I like saving the ink.

I've been running it locally since DTD, but I hope you'll accept this PR to keep the project viable for FAB fans that don't know react 😄 

This brings in card data for DTD, EVO, and around the table

In recent updates, they've moved to new npm packages so I had to change all of the imports.