### PR TITLE
upgraded flesh and blood types and cards libraries to MST

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "homepage": "http://aongaro.github.io/fab-eco-proxy",
   "dependencies": {
+    "@flesh-and-blood/cards": "^2.0.36",
+    "@flesh-and-blood/types": "^2.0.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -15,8 +17,6 @@
     "@types/react-dom": "^18.0.0",
     "@types/uuid": "^9.0.0",
     "bootstrap": "^5.2.3",
-    "@flesh-and-blood/cards": "^2.0.36",
-    "@flesh-and-blood/types": "^2.0.0",
     "fuse.js": "^6.6.2",
     "lodash": "^4.17.21",
     "lunr": "^2.3.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,16 +1206,16 @@
     strip-json-comments "^3.1.1"
 
 "@flesh-and-blood/cards@^2.0.36":
-  version "2.0.39"
-  resolved "https://registry.yarnpkg.com/@flesh-and-blood/cards/-/cards-2.0.39.tgz#c08c3d7f1cb9e0e601402603ad9da974803950bd"
-  integrity sha512-fih8ZGlzE6HpFalSmAL9EjAkIWw6I876vQiWOpUoOmAEK63HE1gZcqxa6EY888U/AT9CyAwF5KtmXCvlPHkbOg==
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/@flesh-and-blood/cards/-/cards-2.1.17.tgz#3b3d75364c22a044133aab3e3d5bb24d2b597ace"
+  integrity sha512-ekCqRUfRcVuS/4AqNCRL+0giUG8niTlqCJbE2O/NEVqRGr4holkSRNFf7NgJCbsqGnmdJXgv1En/ccs3NJEdYA==
   dependencies:
-    "@flesh-and-blood/types" "^2.0.6"
+    "@flesh-and-blood/types" "^2.1.10"
 
-"@flesh-and-blood/types@^2.0.0", "@flesh-and-blood/types@^2.0.6":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@flesh-and-blood/types/-/types-2.0.6.tgz#9735a1410256bcd8203f72dd58187081690923e7"
-  integrity sha512-RQUYrWHVbyULLKoh+NFAY/eh2cdaTe+rvmN0Gr4Gy8qZYYCh3hltS6z5Yg11AqpVOlkTe5FxRz/UeTJSfl5ApA==
+"@flesh-and-blood/types@^2.0.0", "@flesh-and-blood/types@^2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@flesh-and-blood/types/-/types-2.1.10.tgz#2663b081db2776a56758722394a147965b7b0908"
+  integrity sha512-TpyskN66WZq5PJeXApHegtZyZOeGyJ0fHUeDvrSEUztb9cLK3ltG/YjOKmgyPVy6spAyBavluVciaL+YKZ1mcA==
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.7"


### PR DESCRIPTION
Hi there, 

I just wanted to proxy MST-based decks and found out I couldnt. Went ahead and pushed updates to both the `@flesh-and-blood/types` and `@flesh-and-blood/cards` libraries